### PR TITLE
Add support for sorting ground items by price (#34)

### DIFF
--- a/src/main/java/com/hotkeyablemenuswaps/GroundItemPriceSortMode.java
+++ b/src/main/java/com/hotkeyablemenuswaps/GroundItemPriceSortMode.java
@@ -1,0 +1,43 @@
+package com.hotkeyablemenuswaps;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum GroundItemPriceSortMode
+{
+	DISABLED("Disabled")
+		{
+			@Override
+			public Integer getItemPrice(GroundItemsStuff.GroundItem groundItem)
+			{
+				return groundItem.getHaPrice(); // Just in case,
+			}
+		},
+	GE_PRICE("Grand Exchange")
+		{
+			@Override
+			public Integer getItemPrice(GroundItemsStuff.GroundItem groundItem)
+			{
+				return groundItem.getGePrice();
+			}
+		},
+	MAX_GE_OR_ALCH_PRICE("max(GE, High Alch)")
+		{
+			@Override
+			public Integer getItemPrice(GroundItemsStuff.GroundItem groundItem)
+			{
+				return Math.max(groundItem.getGePrice(), groundItem.getHaPrice());
+			}
+		};
+
+	private final String displayName; // For combo box.
+
+	public abstract Integer getItemPrice(GroundItemsStuff.GroundItem groundItem);
+
+	@Override
+	public String toString()
+	{
+		return displayName;
+	}
+
+}

--- a/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsConfig.java
+++ b/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsConfig.java
@@ -126,6 +126,20 @@ public interface HotkeyableMenuSwapsConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "groundItemsPriceSortMode",
+		name = "Price Sort",
+		description =
+			"Grand Exchange: Use Grand Exchange price<br>" +
+			"max(GE, High Alch): Use highest of Grand Exchange price and High Alchemy price" +
+			"Items you've entered into the ground item sort list will use that list's value instead.",
+		section = groundItemSortSection,
+		position = 3
+	)
+	default GroundItemPriceSortMode groundItemsPriceSortMode() {
+		return GroundItemPriceSortMode.DISABLED;
+	}
+
 	@ConfigSection(name = "Bank", description = "All options that swap entries in the bank", position = 0, closedByDefault = true)
 	String bankSection = "bank";
 


### PR DESCRIPTION
# New Feature
- Adds the ability to sort ground items by the max value between the GE and High Alch prices **before** sorting the ground items by the user's specified sorting list

# New Additions
- Create a new method `HotkeyableMenuSwapsPlugin#sortGroundItemsGE` using `HotkeyableMenuSwapsPlugin#sortGroundItems`
	- The reason I am sorting the prices in the new method is to easily and cleanly sort the ground item menu entries **before** the custom sort from the user's list takes place
	- Also more readable code instead of doing the `MenuEntry` sorting before the `highlightedItemValue != null || hiddenItemValue != null` check and after
- Created the class `GroundItemPriceSortMode` to provide user's with a choice on how they want to sort the prices if they choose to enable the price sorting
- Added the new config item with the key "groundItemsPriceSortMethod" that stores the user's price sorting option

# Changes
- Use Slf4j for debugging 
	- Modified some old statements to use Sl4j and created new debug statements
- Use the new _static_ coin id of 995 for coin ground items in `GroundItemsStuff#buildGroundItem`
	- Manually testing lists coins with the id of 995 instead of the previous id of 617
- Move re-used code for retrieving the `GroundItem` from the `Scene` to a new method `HotkeyableMenuSwapsPlugin#getGroundItemFromScene` 
- Modified `GroundItemsStuff#reloadGroundItemPluginLists` with a new parameter `shouldSortByPrice` to account for price sorting


https://github.com/geheur/More-menu-entry-swaps/assets/6964154/813e1295-ac81-42a4-a4dc-029f66c83b71

When watching the video, the list under "Custom hides" is the proper ordering from most expensive to least. Please also keep in mind of the custom ground item order that I pass in later to show that it still works.