### PR TITLE
Reset active hotkeys when client focus is lost

### DIFF
--- a/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsPlugin.java
+++ b/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsPlugin.java
@@ -550,6 +550,7 @@ public class HotkeyableMenuSwapsPlugin extends Plugin implements KeyListener
 		hotkeyTreeRingSwap = null;
 		hotkeyMaxCapeSwap = null;
 		hotkeyBOTDSwap = null;
+		hotkeys = 0;
 		swapUse = false;
 		swapJewelleryBox = false;
 		swapPortalNexus = null;


### PR DESCRIPTION
Fixes #60 where hotkeyed options stay lingering after refocusing client and not holding the key anymore