### PR TITLE
Add hotkey for locking and unlocking inventory slots with left click

### DIFF
--- a/src/main/java/com/hotkeyablemenuswaps/BankSwapMode.java
+++ b/src/main/java/com/hotkeyablemenuswaps/BankSwapMode.java
@@ -21,6 +21,7 @@ enum BankSwapMode implements HotkeyableMenuSwapsPlugin.hasKeybind {
     SWAP_ALL(ShiftDepositMode.DEPOSIT_ALL, ShiftWithdrawMode.WITHDRAW_ALL, HotkeyableMenuSwapsConfig::getBankSwapAllHotkey, 7, 4),
     SWAP_ALL_BUT_1(-1, -1, -1, -1, ShiftWithdrawMode.WITHDRAW_ALL_BUT_1.getMenuAction(), ShiftWithdrawMode.WITHDRAW_ALL_BUT_1.getIdentifier(), ShiftWithdrawMode.WITHDRAW_ALL_BUT_1.getIdentifierChambersStorageUnit(), 7, 4, HotkeyableMenuSwapsConfig::getBankSwapAllBut1Hotkey),
     SWAP_EXTRA_OP(ShiftDepositMode.EXTRA_OP, ShiftWithdrawMode.OFF, HotkeyableMenuSwapsConfig::getBankSwapExtraOpHotkey),
+    LOCK_UNLOCK_SLOT(10, 10, -1, -1, ShiftWithdrawMode.OFF.getMenuAction(), -1, -1, -1, -1, HotkeyableMenuSwapsConfig::lockUnlockSlotHotkey)
     ;
 
     private final int depositIdentifier;

--- a/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsConfig.java
+++ b/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsConfig.java
@@ -323,6 +323,18 @@ public interface HotkeyableMenuSwapsConfig extends Config
 		return Keybind.NOT_SET;
 	}
 
+	@ConfigItem(
+			keyName = "lockUnlockSlotHotkey",
+			name = "Lock/unlock-slot",
+			description = "The hotkey which, when held, lets you lock and unlock slots with left click",
+			section = bankSection,
+			position = 8
+	)
+	default Keybind lockUnlockSlotHotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
 	@ConfigSection(
 			name = "Spirit tree/Fairy ring",
 			description = "All options that swap entries on a spirit tree or fairy ring",

--- a/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsPlugin.java
+++ b/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsPlugin.java
@@ -576,7 +576,11 @@ public class HotkeyableMenuSwapsPlugin extends Plugin implements KeyListener
 		// Deposit- op 2 is the current withdraw amount 1/5/10/x for bank interface
 		if (
 			mode != BankSwapMode.SWAP_ALL_BUT_1
-			&& (menuEntry.getOption().startsWith("Deposit-") || menuEntry.getOption().startsWith("Store") || menuEntry.getOption().startsWith("Donate") || (isPriceChecker && menuEntry.getOption().startsWith("Add")))
+			&& (menuEntry.getOption().startsWith("Deposit-")
+					|| menuEntry.getOption().startsWith("Store")
+					|| menuEntry.getOption().startsWith("Donate")
+					|| menuEntry.getOption().endsWith("-slot")
+					|| (isPriceChecker && menuEntry.getOption().startsWith("Add")))
 		) {
 			final int opId = isDepositBoxPlayerInventory ? mode.getDepositIdentifierDepositBox()
 				: isChambersOfXericStorageUnitPlayerInventory ? mode.getDepositIdentifierChambersStorageUnit()
@@ -602,7 +606,7 @@ public class HotkeyableMenuSwapsPlugin extends Plugin implements KeyListener
 			} else if (isPriceChecker && menuEntry.getOption().startsWith("Remove")) {
 				opId = mode.getPriceCheckerIdentifier();
 			}
-			
+
 			if (opId != -1)
 			{
 				bankModeSwap(opId);


### PR DESCRIPTION
Adds a hotkey for the new inventory slot locking. Available in the bank and deposit boxes.

![image](https://github.com/user-attachments/assets/a3b932e0-bc70-4c80-8852-3f0939f5930e)


https://github.com/user-attachments/assets/aa74fd66-6087-4d92-9082-4b16c1570d0f

