### PR TITLE
Defer rune pouch enum lookup until logged in

### DIFF
--- a/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsPlugin.java
+++ b/src/main/java/com/hotkeyablemenuswaps/HotkeyableMenuSwapsPlugin.java
@@ -74,7 +74,6 @@ import net.runelite.api.gameval.InterfaceID;
 import static net.runelite.api.gameval.InterfaceID.*;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetUtil;
-import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.Keybind;
 import net.runelite.client.config.RuneLiteConfig;
@@ -115,7 +114,6 @@ public class HotkeyableMenuSwapsPlugin extends Plugin implements KeyListener
 	@Inject private GroundItemsStuff groundItemsStuff;
 	@Inject private EventBus eventBus;
 	@Inject private RunepouchUtils runepouchUtils;
-	@Inject private ClientThread clientThread;
 
 	// If a hotkey corresponding to a swap is currently held, these variables will be non-null. currentBankModeSwap is an exception because it uses menu entry swapper's bank swap enum, which already has an "off" value.
 	// These variables do not factor in left-click swaps.
@@ -160,8 +158,6 @@ public class HotkeyableMenuSwapsPlugin extends Plugin implements KeyListener
 		resetHotkeys();
 
 		keyManager.registerKeyListener(this);
-
-		clientThread.invoke(runepouchUtils::startUp);
 
 		examineCancelLateRemoval = config.examineCancelLateRemoval();
 

--- a/src/main/java/com/hotkeyablemenuswaps/RunepouchUtils.java
+++ b/src/main/java/com/hotkeyablemenuswaps/RunepouchUtils.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
+import net.runelite.api.GameState;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.Varbits;
@@ -17,11 +18,6 @@ public class RunepouchUtils
 	@Inject private Client client;
 
 	BiMap<Integer, Integer> runeIDItemIDBiMap;
-
-	public void startUp()
-	{
-		createRuneIDItemIDBiMap();
-	}
 
 	public boolean inventoryContainsRunePouch(ItemContainer inventory)
 	{
@@ -45,12 +41,17 @@ public class RunepouchUtils
 
 	public boolean isItemARune(int itemID)
 	{
-		return runeIDItemIDBiMap.inverse().containsKey(itemID);
+		createRuneIDItemIDBiMap();
+		return runeIDItemIDBiMap != null && runeIDItemIDBiMap.inverse().containsKey(itemID);
 	}
 
+	// Builds the map lazily on the client thread once the client is logged in. Building it eagerly at
+	// plugin startup NPEs at the login screen because client.getEnum requires the game's enum cache,
+	// which is not loaded before login.
 	private void createRuneIDItemIDBiMap()
 	{
 		if (runeIDItemIDBiMap != null) return;
+		if (client.getGameState() != GameState.LOGGED_IN) return;
 		// getIntVals starts at index=1 -> Rune pouch rune starts from 1 and goes to n (22 runes)
 		EnumComposition ec = client.getEnum(EnumID.RUNEPOUCH_RUNE);
 		int[] runeIDs = ec.getKeys();
@@ -64,6 +65,7 @@ public class RunepouchUtils
 
 	public int getItemIDFromRuneID(int runeID)
 	{
-		return runeIDItemIDBiMap.getOrDefault(runeID, -1);
+		createRuneIDItemIDBiMap();
+		return runeIDItemIDBiMap == null ? -1 : runeIDItemIDBiMap.getOrDefault(runeID, -1);
 	}
 }


### PR DESCRIPTION
`RunepouchUtils.startUp` runs `client.getEnum(EnumID.RUNEPOUCH_RUNE)` on the client thread the moment the plugin is enabled, including at the login screen. Before login the game's enum cache is not loaded, so `getEnum` throws inside the client and the plugin startup fails with an uncaught NullPointerException. This change removes the eager `clientThread.invoke(runepouchUtils::startUp)` call and instead builds the rune-ID/item-ID BiMap lazily on first use, guarded by a `GameState.LOGGED_IN` check, with the lookup accessors returning safe defaults if the map has not been built yet. The map is still built exactly once, and only the rune pouch ground-item sort (which only runs while logged in) needs it.

Trigger line: `src/main/java/com/hotkeyablemenuswaps/RunepouchUtils.java:55` (`client.getEnum` reached via `startUp`). Stack trace observed on the Plugin Hub build (RuneLite 1.12.31.1) at the login screen. Compiles with `gradlew build`.